### PR TITLE
pin lighthouse check action to previous revision

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -23,7 +23,7 @@ jobs:
           mkdir -p /tmp/artifacts ./reports
           
       - name: Generate the report
-        uses: foo-software/lighthouse-check-action@master
+        uses: foo-software/lighthouse-check-action@v10.0.0
         with:
           author: ${{ github.actor }}
           outputDirectory: /tmp/artifacts


### PR DESCRIPTION
* This commit [a80267da2e0244b8a2e457a8575fc47590615852](https://github.com/foo-software/lighthouse-check-action/commit/a80267da2e0244b8a2e457a8575fc47590615852) in the [lighthouse-check-action](https://github.com/foo-software/lighthouse-check-action) repository broke the individual reports

Resolves #1 